### PR TITLE
RethinkDB 2.3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rethinkdb:2.3.5
+FROM rethinkdb:2.3.6
 MAINTAINER xkodiak
 
 RUN apt update && apt install -y curl


### PR DESCRIPTION
Minor Dockerfile update to use RethinkDB 2.3.6