### PR TITLE
#2 upgrade: rethinkdb:2.4 - Night Of The Living Dead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rethinkdb:2.3.6
+FROM rethinkdb:2.4
 MAINTAINER xkodiak
 
 RUN apt update && apt install -y curl


### PR DESCRIPTION
issue: https://github.com/ferociousbyte/rancher-rethinkdb/issues/2

- Docker release: https://hub.docker.com/layers/rethinkdb/library/rethinkdb/2.4/images/sha256-1e9da7701bcd0fd654d1f7eaa4f12fae163e90bca6a329a085751dce8a00c562?context=explore
- rethinkdb release: https://github.com/rethinkdb/rethinkdb/releases/tag/v2.4.0